### PR TITLE
fix: add missing imports to headless CLI case and extract modules

### DIFF
--- a/lockknife_headless_cli/case.py
+++ b/lockknife_headless_cli/case.py
@@ -4,9 +4,35 @@ import sys
 
 import click
 
+from lockknife.core.case import (
+    case_artifact_details,
+    case_artifact_lineage,
+    case_lineage_graph,
+    case_output_path,
+    create_case_workspace,
+    export_case_bundle,
+    load_case_manifest,
+    query_case_artifacts,
+    register_case_artifact,
+    register_case_artifact_with_status,
+    summarize_case_manifest,
+)
 from lockknife.core.cli_instrumentation import LockKnifeGroup
+from lockknife.core.custody import list_entries
+from lockknife.core.output import console
+from lockknife.core.serialize import write_json
+from lockknife.modules._case_enrichment_orchestrator import run_case_enrichment
 from lockknife_headless_cli._case_cli_core import register as _register_core
 from lockknife_headless_cli._case_cli_enrichment import register as _register_enrichment
+from lockknife_headless_cli._case_cli_helpers import (
+    _artifact_ref_kwargs,
+    _case_filter_kwargs,
+    _render_enrichment_text,
+    _render_filter_summary,
+    _render_graph_text,
+    _render_rows,
+    _render_search_summary,
+)
 from lockknife_headless_cli._case_cli_queries import register as _register_queries
 
 

--- a/lockknife_headless_cli/extract.py
+++ b/lockknife_headless_cli/extract.py
@@ -4,8 +4,32 @@ import sys
 
 import click
 
+from lockknife.core.case import register_case_artifact
 from lockknife.core.cli_instrumentation import LockKnifeGroup
 from lockknife.core.logging import get_logger
+from lockknife.core.output import console
+from lockknife.modules.extraction._browser_extract_chrome import (
+    extract_chrome_bookmarks,
+    extract_chrome_cookies,
+    extract_chrome_downloads,
+    extract_chrome_history,
+    extract_chrome_saved_logins,
+)
+from lockknife.modules.extraction._browser_extract_firefox import (
+    extract_firefox_bookmarks,
+    extract_firefox_history,
+    extract_firefox_saved_logins,
+)
+from lockknife.modules.extraction.call_logs import extract_call_logs
+from lockknife.modules.extraction.contacts import extract_contacts
+from lockknife.modules.extraction.location import extract_location_artifacts
+from lockknife.modules.extraction.media import extract_media_with_exif
+from lockknife.modules.extraction.messaging import (
+    extract_signal_messages,
+    extract_telegram_messages,
+    extract_whatsapp_messages,
+)
+from lockknife.modules.extraction.sms import extract_sms
 from lockknife_headless_cli._extract_all import register as _register_all
 from lockknife_headless_cli._extract_basic import register as _register_basic
 from lockknife_headless_cli._extract_browser import register as _register_browser


### PR DESCRIPTION
## Problem

Both `lockknife_headless_cli/case.py` and `lockknife_headless_cli/extract.py` use a `sys.modules[__name__]` injection pattern — they pass themselves as `cli` to their `register()` sub-modules, which then call functions via `cli.xxx`. However, neither module imported the functions those sub-modules call, causing `AttributeError` at runtime.

**Errors before this fix:**
```
AttributeError: module 'lockknife_headless_cli.case' has no attribute 'create_case_workspace'
AttributeError: module 'lockknife_headless_cli.extract' has no attribute 'extract_sms'
```

This meant `lockknife case init`, `lockknife extract all`, and all dependent commands crashed immediately on invocation.

## Fix

Added the missing imports to both modules:

**`case.py`** — imports from `lockknife.core.case`, `lockknife.core.custody`, `lockknife.core.output`, `lockknife.core.serialize`, `lockknife.modules._case_enrichment_orchestrator`, and `lockknife_headless_cli._case_cli_helpers` that `_case_cli_core`, `_case_cli_queries`, and `_case_cli_enrichment` all call via `cli.xxx`.

**`extract.py`** — imports from `lockknife.core.case`, `lockknife.core.output`, and all extraction modules (`_browser_extract_chrome`, `_browser_extract_firefox`, `call_logs`, `contacts`, `location`, `media`, `messaging`, `sms`) that `_extract_basic`, `_extract_all`, `_extract_browser`, `_extract_messaging`, and `_extract_misc` call via `cli.xxx`.

## Testing

Verified `lockknife case init`, `lockknife case enrich`, `lockknife extract all`, `lockknife extract sms`, and related commands run without `AttributeError` after this fix.

## Notes

The same pattern exists in `apk.py`, `intel.py`, and `ai.py` — those may need the same treatment if their sub-modules reference functions via `cli.xxx`.